### PR TITLE
Added ability to modify trace width value

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,6 +109,13 @@
               </div>
             </div>
             <div class="mb-3">
+              <label for="">Trace Width <span class="text-muted small">Lower widths produce sharper images (mm)</span></label>
+              <input type="text" class="form-control" id="traceWidth" placeholder="Trace Width" value="0.1" required>
+              <div class="invalid-feedback">
+                Trace Width is required.
+              </div>
+            </div>
+            <div class="mb-3">
               <label for="">Signal Name <span class="text-muted small">(for copper layers, ignored by otherwise)</span></label>
               <input type="text" class="form-control" id="signalName" placeholder="Signal Name" value="GND" required>
               <div class="invalid-feedback">

--- a/svgtoeagle.js
+++ b/svgtoeagle.js
@@ -148,7 +148,8 @@ function plotPoly(points, isFilled) {
 
 function drawSVG() {
   if (container===undefined) return;
-  var FLIP_HORIZ = document.getElementById("flipImage").checked;
+  TRACEWIDTH = parseFloat(document.getElementById("traceWidth").value);
+  FLIP_HORIZ = document.getElementById("flipImage").checked;
   var EAGLE_LAYER = document.getElementById("eagleLayer").value;
   var SIGNAL_NAME = document.getElementById("signalName").value;
   var EAGLE_FORMAT = document.querySelector('input[name="eagleformat"]:checked').value;


### PR DESCRIPTION
## Description

First, I would like to thank you for this wonderful project. I have been a huge fan and user.

For this pull request, I added the ability to edit and modify the trace width from the web page.

Lowering the trace width from the default value `0.1mm` produces sharper images. I always had to modify the output script by hand to produce finer images, especially on the silkscreen layers.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I run multiple SVG files on it, and it produced the expected output script with the modified trace width. I also verified it through Importing it to EAGLE

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings