### PR TITLE
Prevent generation of polygons with 2 or 3 points as this creates an …

### DIFF
--- a/svgtoeagle.js
+++ b/svgtoeagle.js
@@ -260,6 +260,9 @@ function drawSVG() {
       points = simplify(points, SIMPLIFY, SIMPLIFYHQ);
       polys.push(points);
     }
+
+    if (points.length <= 2) continue; // Too few points create Eagle script import error (issue #17)
+
     ctx.strokeStyle = `hsl(${col+=40},100%,50%)`;
     ctx.fillStyle = `hsla(${col+=40},100%,50%,0.4)`;
 


### PR DESCRIPTION
…error on import to Eagle. Fix for issue #17.