### PR TITLE
Changed .scr filename to be based on .svg name

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
            <textarea class="form-control" id="result" rows="9"></textarea>
           </div>
           <div class="mb-3">
-            <button class="btn btn-primary btn-lg btn-block" id="dwn-btn" type="submit" onclick="download_script();" disabled>Download eagle script</button>
+            <button class="btn btn-primary btn-lg btn-block" id="dwn-btn" type="submit" onclick="download_script(document.getElementById('fileLoader').value);" disabled>Download eagle script</button>
           </div>
         </div>
 

--- a/svgtoeagle.js
+++ b/svgtoeagle.js
@@ -10,8 +10,14 @@ var TRACEWIDTH = 0.1; // in mm
 // Start file download.
 function download_script(filename, text) {
   var text = document.getElementById("result").value;
-  var filename = "import_svg.scr";
   var element = document.createElement('a');
+
+  if (typeof filename === 'undefined') { 
+    filename = 'import_svg.scr'; 
+  } else {
+    var patternFileName = /([^\\\/]+)\.svg$/i;
+    var filename= filename.match(patternFileName)[1] + ".scr";
+  }
 
   element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
   element.setAttribute('download', filename);


### PR DESCRIPTION
I am using this tool many times within a single project and it got a little tiresome to change the filename every time when saving. I have only tested this on Windows but I believe it will work properly on operating systems that use either a / or a \ for delimiting paths. Thanks for creating this, btw!!